### PR TITLE
Improve app configuration

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,30 @@ configurations {
     ktlint
 }
 
+// Read values from gradle.properties or system environment variable
+def getBackendUrl() {
+    return readProperty('STRIPE_EXAMPLE_BACKEND_URL')
+}
+
+def getPublishableKey() {
+    return readProperty('STRIPE_EXAMPLE_PUBLISHABLE_KEY')
+}
+
+def getAccountId() {
+    return readProperty('STRIPE_ACCOUNT_ID')
+}
+
+private def readProperty(name) {
+    final String propValue
+    if (hasProperty(name)) {
+        propValue = property(name)
+    } else {
+        propValue = System.getenv(name)
+    }
+
+    return propValue?.trim() ? propValue : ""
+}
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion
@@ -24,7 +48,11 @@ android {
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         manifestPlaceholders = [
-                PRICE_MULTIPLIER: 1.0
+                PRICE_MULTIPLIER: 1.0,
+
+                BACKEND_URL: getBackendUrl(),
+                PUBLISHABLE_KEY: getPublishableKey(),
+                STRIPE_ACCOUNT_ID: getAccountId()
         ]
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,16 @@
             android:name="com.stripe.samplestore.price_multiplier"
             android:value="${PRICE_MULTIPLIER}" />
 
+        <meta-data
+            android:name="com.stripe.example.metadata.backend_url"
+            android:value="${BACKEND_URL}" />
+        <meta-data
+            android:name="com.stripe.example.metadata.publishable_key"
+            android:value="${PUBLISHABLE_KEY}" />
+        <meta-data
+            android:name="com.stripe.example.metadata.stripe_account_id"
+            android:value="${STRIPE_ACCOUNT_ID}" />
+
         <activity android:name=".StoreActivity"
                   android:theme="@style/AppTheme.NoActionBar">
             <intent-filter>

--- a/app/src/main/java/com/stripe/samplestore/BackendApiFactory.kt
+++ b/app/src/main/java/com/stripe/samplestore/BackendApiFactory.kt
@@ -1,28 +1,33 @@
 package com.stripe.samplestore
 
+import android.content.Context
 import com.facebook.stetho.okhttp3.StethoInterceptor
 import com.google.gson.GsonBuilder
+import com.stripe.samplestore.service.BackendApi
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 
 /**
- * Factory instance to keep our Retrofit instance.
+ * Factory to generate our Retrofit instance.
  */
-object RetrofitFactory {
-    val instance: Retrofit
+internal class BackendApiFactory internal constructor(private val backendUrl: String) {
 
-    init {
+    constructor(context: Context) : this(Settings(context).backendUrl)
+
+    fun create(): BackendApi {
         // Set your desired log level. Use Level.BODY for debugging errors.
         // Adding Rx so the calls can be Observable, and adding a Gson converter with
         // leniency to make parsing the results simple.
-
         val logging = HttpLoggingInterceptor()
-            .setLevel(HttpLoggingInterceptor.Level.BASIC)
+            .setLevel(HttpLoggingInterceptor.Level.BODY)
 
         val httpClient = OkHttpClient.Builder()
+            .connectTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .addInterceptor(logging)
             .addNetworkInterceptor(StethoInterceptor())
             .build()
@@ -30,11 +35,17 @@ object RetrofitFactory {
         val gson = GsonBuilder()
             .setLenient()
             .create()
-        instance = Retrofit.Builder()
-            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+
+        return Retrofit.Builder()
             .addConverterFactory(GsonConverterFactory.create(gson))
-            .baseUrl(Settings.BASE_URL)
+            .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
+            .baseUrl(backendUrl)
             .client(httpClient)
             .build()
+            .create(BackendApi::class.java)
+    }
+
+    private companion object {
+        private const val TIMEOUT_SECONDS = 15L
     }
 }

--- a/app/src/main/java/com/stripe/samplestore/Settings.kt
+++ b/app/src/main/java/com/stripe/samplestore/Settings.kt
@@ -1,42 +1,81 @@
 package com.stripe.samplestore
 
+import android.content.Context
+import android.content.pm.PackageManager
 import com.stripe.android.model.PaymentMethod
 
 /**
- * See [Configuring the samplestore app](https://github.com/stripe/stripe-android#configuring-the-samplestore-app)
+ * See [Configuring the example app](https://github.com/stripe/stripe-android#building-the-example-project)
  * for instructions on how to configure the app before running it.
  */
-internal object Settings {
-    /**
-     * Set to the base URL of your test backend. If you are using
-     * [example-ios-backend](https://github.com/stripe/example-ios-backend),
-     * the URL will be something like `https://hidden-beach-12345.herokuapp.com/`.
-     */
-    const val BASE_URL = "put your base url here"
+class Settings(context: Context) {
+    private val appContext = context.applicationContext
+    private val backendMetadata = getMetadata(METADATA_KEY_BACKEND_URL_KEY)
+    private val publishableKeyMetadata = getMetadata(METADATA_KEY_PUBLISHABLE_KEY)
+    private val stripeAccountIdMetadata = getMetadata(METADATA_KEY_STRIPE_ACCOUNT_ID)
 
-    /**
-     * Set to publishable key from https://dashboard.stripe.com/test/apikeys
-     */
-    const val PUBLISHABLE_KEY = "pk_test_your_key_goes_here"
+    val backendUrl: String
+        get() {
+            return backendMetadata ?: BASE_URL
+        }
 
-    /**
-     * Optionally, set to a Connect Account id to use for API requests to test Connect
-     *
-     * See https://dashboard.stripe.com/test/connect/accounts/overview
-     */
-    val STRIPE_ACCOUNT_ID: String? = null
+    val publishableKey: String
+        get() {
+            return publishableKeyMetadata ?: PUBLISHABLE_KEY
+        }
 
-    /**
-     * Three-letter ISO [currency code](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-currency),
-     * in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
-     */
-    const val CURRENCY = "usd"
+    val stripeAccountId: String?
+        get() {
+            return stripeAccountIdMetadata ?: STRIPE_ACCOUNT_ID
+        }
 
-    /**
-     * The list of [payment method types](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method_types)
-     * (e.g. card) that this PaymentIntent is allowed to use.
-     */
-    val ALLOWED_PAYMENT_METHOD_TYPES = listOf(
-        PaymentMethod.Type.Card
-    )
+    private fun getMetadata(key: String): String? {
+        return appContext.packageManager
+            .getApplicationInfo(appContext.packageName, PackageManager.GET_META_DATA)
+            .metaData
+            .getString(key)
+            .takeIf { it?.isNotBlank() == true }
+    }
+
+    internal companion object {
+        /**
+         * Three-letter ISO [currency code](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-currency),
+         * in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+         */
+        const val CURRENCY = "usd"
+
+        /**
+         * The list of [payment method types](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method_types)
+         * (e.g. card) that this PaymentIntent is allowed to use.
+         */
+        val ALLOWED_PAYMENT_METHOD_TYPES = listOf(
+            PaymentMethod.Type.Card
+        )
+
+        /**
+         * Set to the base URL of your test backend. If you are using
+         * [example-ios-backend](https://github.com/stripe/example-ios-backend),
+         * the URL will be something like `https://hidden-beach-12345.herokuapp.com/`.
+         */
+        private const val BASE_URL = "put your base url here"
+
+        /**
+         * Set to publishable key from https://dashboard.stripe.com/test/apikeys
+         */
+        private const val PUBLISHABLE_KEY = "pk_test_your_key_goes_here"
+
+        /**
+         * Optionally, set to a Connect Account id to use for API requests to test Connect
+         *
+         * See https://dashboard.stripe.com/test/connect/accounts/overview
+         */
+        private val STRIPE_ACCOUNT_ID: String? = null
+
+        private const val METADATA_KEY_BACKEND_URL_KEY =
+            "com.stripe.example.metadata.backend_url"
+        private const val METADATA_KEY_PUBLISHABLE_KEY =
+            "com.stripe.example.metadata.publishable_key"
+        private const val METADATA_KEY_STRIPE_ACCOUNT_ID =
+            "com.stripe.example.metadata.stripe_account_id"
+    }
 }

--- a/app/src/main/java/com/stripe/samplestore/StoreActivity.kt
+++ b/app/src/main/java/com/stripe/samplestore/StoreActivity.kt
@@ -16,6 +16,10 @@ import io.reactivex.disposables.CompositeDisposable
 
 class StoreActivity : AppCompatActivity(), StoreAdapter.TotalItemsChangedListener {
 
+    private val settings: Settings by lazy {
+        Settings(applicationContext)
+    }
+
     private val compositeDisposable = CompositeDisposable()
 
     private lateinit var goToCartButton: FloatingActionButton
@@ -38,7 +42,7 @@ class StoreActivity : AppCompatActivity(), StoreAdapter.TotalItemsChangedListene
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_store)
 
-        PaymentConfiguration.init(this, Settings.PUBLISHABLE_KEY)
+        PaymentConfiguration.init(this, settings.publishableKey)
         goToCartButton = findViewById(R.id.fab_checkout)
         storeAdapter = StoreAdapter(this, priceMultiplier)
 
@@ -51,7 +55,7 @@ class StoreActivity : AppCompatActivity(), StoreAdapter.TotalItemsChangedListene
         recyclerView.adapter = storeAdapter
 
         goToCartButton.setOnClickListener { storeAdapter.launchPurchaseActivityWithCart() }
-        setupCustomerSession(Settings.STRIPE_ACCOUNT_ID)
+        setupCustomerSession(settings.stripeAccountId)
     }
 
     override fun onDestroy() {
@@ -117,7 +121,7 @@ class StoreActivity : AppCompatActivity(), StoreAdapter.TotalItemsChangedListene
 
     private fun setupCustomerSession(stripeAccountId: String?) {
         // CustomerSession only needs to be initialized once per app.
-        ephemeralKeyProvider = SampleStoreEphemeralKeyProvider(stripeAccountId)
+        ephemeralKeyProvider = SampleStoreEphemeralKeyProvider(applicationContext, stripeAccountId)
         CustomerSession.initCustomerSession(this, ephemeralKeyProvider, stripeAccountId)
     }
 

--- a/app/src/main/java/com/stripe/samplestore/service/SampleStoreEphemeralKeyProvider.kt
+++ b/app/src/main/java/com/stripe/samplestore/service/SampleStoreEphemeralKeyProvider.kt
@@ -1,29 +1,30 @@
 package com.stripe.samplestore.service
 
+import android.content.Context
 import androidx.annotation.Size
 import com.stripe.android.EphemeralKeyProvider
 import com.stripe.android.EphemeralKeyUpdateListener
-import com.stripe.samplestore.RetrofitFactory
+import com.stripe.samplestore.BackendApiFactory
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
 import java.io.IOException
 
 class SampleStoreEphemeralKeyProvider @JvmOverloads constructor(
+    context: Context,
     private val stripeAccountId: String? = null
 ) : EphemeralKeyProvider {
 
     private val compositeDisposable: CompositeDisposable = CompositeDisposable()
-    private val backendApi: BackendApi =
-        RetrofitFactory.instance.create(BackendApi::class.java)
+    private val backendApi: BackendApi = BackendApiFactory(context).create()
 
     override fun createEphemeralKey(
         @Size(min = 4) apiVersion: String,
         keyUpdateListener: EphemeralKeyUpdateListener
     ) {
         val params = hashMapOf("api_version" to apiVersion)
-        if (stripeAccountId != null) {
-            params["stripe_account"] = stripeAccountId
+        stripeAccountId?.let {
+            params["stripe_account"] = it
         }
 
         compositeDisposable.add(backendApi.createEphemeralKey(params)


### PR DESCRIPTION
Summary
- Add logic to read configuration settings from local
  `gradle.properties` or environment variables and write out
  to `AndroidManifest.xml` at build time.
- Update `Settings` to be a class that takes a `Context`
  to read metadata from `AndroidManifest.xml`.
  Retain constants in `Settings` to preserve existing
  functionality.
- Update `RetrofitFactory` accordingly.

Motivation
Simplify configuration

[0] https://docs.travis-ci.com/user/environment-variables/