### PR TITLE
Increase readability

### DIFF
--- a/app/src/main/java/com/stripe/samplestore/CustomerRetrievalException.kt
+++ b/app/src/main/java/com/stripe/samplestore/CustomerRetrievalException.kt
@@ -1,0 +1,9 @@
+package com.stripe.samplestore
+
+import com.stripe.android.StripeError
+
+data class CustomerRetrievalException(
+    val errorCode: Int,
+    val errorMessage: String,
+    val stripeError: StripeError?
+) : Throwable(errorMessage)

--- a/app/src/main/java/com/stripe/samplestore/service/BackendApi.kt
+++ b/app/src/main/java/com/stripe/samplestore/service/BackendApi.kt
@@ -1,6 +1,6 @@
 package com.stripe.samplestore.service
 
-import io.reactivex.Observable
+import io.reactivex.Single
 import okhttp3.ResponseBody
 import retrofit2.http.Body
 import retrofit2.http.FieldMap
@@ -18,7 +18,7 @@ interface BackendApi {
      * {"secret": "pi_1Eu5SqCRMb_secret_O2Avhk5V0Pjeo"}
      */
     @POST("create_payment_intent")
-    fun createPaymentIntent(@Body params: HashMap<String, Any>): Observable<ResponseBody>
+    fun createPaymentIntent(@Body params: HashMap<String, Any>): Single<ResponseBody>
 
     /**
      * Used for Payment Intent Manual confirmation
@@ -30,12 +30,12 @@ interface BackendApi {
      * {"secret": "pi_1Eu5SqCRMb_secret_O2Avhk5V0Pjeo"}
      */
     @POST("confirm_payment_intent")
-    fun confirmPaymentIntent(@Body params: HashMap<String, Any>): Observable<ResponseBody>
+    fun confirmPaymentIntent(@Body params: HashMap<String, Any>): Single<ResponseBody>
 
     @POST("create_setup_intent")
-    fun createSetupIntent(@Body params: HashMap<String, Any>): Observable<ResponseBody>
+    fun createSetupIntent(@Body params: HashMap<String, Any>): Single<ResponseBody>
 
     @FormUrlEncoded
     @POST("ephemeral_keys")
-    fun createEphemeralKey(@FieldMap apiVersionMap: HashMap<String, String>): Observable<ResponseBody>
+    fun createEphemeralKey(@FieldMap apiVersionMap: HashMap<String, String>): Single<ResponseBody>
 }


### PR DESCRIPTION
There are two main scenarios in `PaymentActivity`:
- Handling payment intent
- Handling setup intent

Both of them were written in imperative style, with multiple nested `side effects` which means that the majority of methods had signature `(Any) -> Unit` with nested `RxJava` subscriptions in them. As a fact, all those chains were handled in multiple ways, with repeating `onSubscribe{ showLoading() }` etc

By organizing code like this, we call `.subscribe()` method only on the edge, the place where we actually handle whole `RX` chain, our `scenario` or `story`. This helps us handling errors in one place by firing `Observable.error()` on each step of scenario - it will cancel entire chain and will be thrown in `onError`. This also allows us to call methods like `startLoading()` and `stopLoading` only once.   