### PR TITLE
Create StoreViewModel and PaymentViewModel

### DIFF
--- a/app/src/main/java/com/stripe/samplestore/CheckoutContract.kt
+++ b/app/src/main/java/com/stripe/samplestore/CheckoutContract.kt
@@ -6,15 +6,21 @@ import android.os.Parcelable
 import androidx.activity.result.contract.ActivityResultContract
 import kotlinx.android.parcel.Parcelize
 
-internal class CheckoutContract : ActivityResultContract<StoreCart, CheckoutContract.Result>() {
-    override fun createIntent(context: Context, cart: StoreCart?): Intent {
+internal class CheckoutContract : ActivityResultContract<CheckoutContract.Args, CheckoutContract.Result>() {
+    override fun createIntent(context: Context, args: Args?): Intent {
         return Intent(context, PaymentActivity::class.java)
-            .putExtra(EXTRA_CART, cart)
+            .putExtra(EXTRA_ARGS, args)
     }
 
     override fun parseResult(resultCode: Int, intent: Intent?): Result? {
         return intent?.getParcelableExtra(EXTRA_RESULT)
     }
+
+    @Parcelize
+    data class Args(
+        val cart: StoreCart,
+        val customerId: String
+    ) : Parcelable
 
     sealed class Result : Parcelable {
         @Parcelize
@@ -25,7 +31,7 @@ internal class CheckoutContract : ActivityResultContract<StoreCart, CheckoutCont
     }
 
     companion object {
-        const val EXTRA_CART = "extra_cart"
+        const val EXTRA_ARGS = "extra_args"
         const val EXTRA_RESULT = "result_extra"
     }
 }

--- a/app/src/main/java/com/stripe/samplestore/PaymentViewModel.kt
+++ b/app/src/main/java/com/stripe/samplestore/PaymentViewModel.kt
@@ -1,0 +1,119 @@
+package com.stripe.samplestore
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.stripe.android.ApiResultCallback
+import com.stripe.android.model.PaymentIntent
+import com.stripe.android.model.SetupIntent
+import io.reactivex.android.schedulers.AndroidSchedulers
+import io.reactivex.disposables.CompositeDisposable
+import io.reactivex.schedulers.Schedulers
+import org.json.JSONObject
+
+internal class PaymentViewModel(application: Application) : AndroidViewModel(application) {
+    private val context = application.applicationContext
+    private val service = BackendApiFactory(context).create()
+    private val stripe = StripeFactory(context).create()
+    private val compositeDisposable = CompositeDisposable()
+
+    fun createPaymentIntent(params: Map<String, Any>): LiveData<Result<JSONObject>> {
+        val liveData = MutableLiveData<Result<JSONObject>>()
+
+        compositeDisposable.add(
+            service.createPaymentIntent(params.toMutableMap())
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                    {
+                        liveData.value = Result.success(JSONObject(it.string()))
+                    },
+                    {
+                        liveData.value = Result.failure(it)
+                    }
+                )
+        )
+
+        return liveData
+    }
+
+    fun createSetupIntent(params: Map<String, Any>): LiveData<Result<JSONObject>> {
+        val liveData = MutableLiveData<Result<JSONObject>>()
+
+        compositeDisposable.add(
+            service
+                .createSetupIntent(params.toMutableMap())
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                    {
+                        liveData.value = Result.success(JSONObject(it.string()))
+                    },
+                    {
+                        liveData.value = Result.failure(it)
+                    }
+                )
+        )
+
+        return liveData
+    }
+
+    fun confirmStripeIntent(params: Map<String, Any>): LiveData<Result<JSONObject>> {
+        val liveData = MutableLiveData<Result<JSONObject>>()
+        compositeDisposable.add(
+            service.confirmPaymentIntent(params.toMutableMap())
+                .subscribeOn(Schedulers.io())
+                .observeOn(AndroidSchedulers.mainThread())
+                .subscribe(
+                    {
+                        liveData.value = Result.success(JSONObject(it.string()))
+                    },
+                    {
+                        liveData.value = Result.failure(it)
+                    }
+                )
+        )
+
+        return liveData
+    }
+
+    fun retrievePaymentIntent(clientSecret: String): LiveData<Result<PaymentIntent>> {
+        val liveData = MutableLiveData<Result<PaymentIntent>>()
+        stripe.retrievePaymentIntent(
+            clientSecret,
+            callback = object : ApiResultCallback<PaymentIntent> {
+                override fun onError(e: Exception) {
+                    liveData.value = Result.failure(e)
+                }
+
+                override fun onSuccess(result: PaymentIntent) {
+                    liveData.value = Result.success(result)
+                }
+            }
+        )
+        return liveData
+    }
+
+    fun retrieveSetupIntent(clientSecret: String): LiveData<Result<SetupIntent>> {
+        val liveData = MutableLiveData<Result<SetupIntent>>()
+        stripe.retrieveSetupIntent(
+            clientSecret,
+            callback = object : ApiResultCallback<SetupIntent> {
+                override fun onError(e: Exception) {
+                    liveData.value = Result.failure(e)
+                }
+
+                override fun onSuccess(result: SetupIntent) {
+                    liveData.value = Result.success(result)
+                }
+            }
+        )
+        return liveData
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        compositeDisposable.dispose()
+    }
+}

--- a/app/src/main/java/com/stripe/samplestore/StoreAdapter.kt
+++ b/app/src/main/java/com/stripe/samplestore/StoreAdapter.kt
@@ -5,13 +5,14 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.activity.result.ActivityResultLauncher
 import androidx.recyclerview.widget.RecyclerView
+import com.stripe.android.model.Customer
 import com.stripe.samplestore.databinding.StoreItemBinding
 import java.util.Currency
 
 internal class StoreAdapter internal constructor(
     private val activity: StoreActivity,
     private val priceMultiplier: Float,
-    private val checkoutResultContract: ActivityResultLauncher<StoreCart>,
+    private val checkoutResultContract: ActivityResultLauncher<CheckoutContract.Args>,
     private val itemsChangedCallback: (Boolean) -> Unit = {}
 ) : RecyclerView.Adapter<StoreAdapter.ViewHolder>() {
 
@@ -23,6 +24,8 @@ internal class StoreAdapter internal constructor(
     // otherwise functional if you switched that assumption on the backend and passed
     // currency code as a parameter.
     private val cart: IntArray = IntArray(Product.values().size)
+
+    internal var customer: Customer? = null
 
     init {
         setHasStableIds(true)
@@ -95,7 +98,12 @@ internal class StoreAdapter internal constructor(
             }
         }
 
-        checkoutResultContract.launch(cart)
+        checkoutResultContract.launch(
+            CheckoutContract.Args(
+                cart,
+                customerId = requireNotNull(customer?.id)
+            )
+        )
     }
 
     internal fun clearItemSelections() {

--- a/app/src/main/java/com/stripe/samplestore/StoreApplication.kt
+++ b/app/src/main/java/com/stripe/samplestore/StoreApplication.kt
@@ -1,0 +1,32 @@
+package com.stripe.samplestore
+
+import android.os.StrictMode
+import androidx.multidex.MultiDexApplication
+import com.stripe.android.PaymentConfiguration
+
+class StoreApplication : MultiDexApplication() {
+
+    override fun onCreate() {
+        PaymentConfiguration.init(this, Settings(this).publishableKey)
+
+        StrictMode.setThreadPolicy(
+            StrictMode.ThreadPolicy.Builder()
+                .detectDiskReads()
+                .detectDiskWrites()
+                .detectAll()
+                .penaltyLog()
+                .build()
+        )
+
+        StrictMode.setVmPolicy(
+            StrictMode.VmPolicy.Builder()
+                .detectLeakedSqlLiteObjects()
+                .detectLeakedClosableObjects()
+                .penaltyLog()
+                .penaltyDeath()
+                .build()
+        )
+
+        super.onCreate()
+    }
+}

--- a/app/src/main/java/com/stripe/samplestore/StoreViewModel.kt
+++ b/app/src/main/java/com/stripe/samplestore/StoreViewModel.kt
@@ -1,0 +1,54 @@
+package com.stripe.samplestore
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.stripe.android.CustomerSession
+import com.stripe.android.StripeError
+import com.stripe.android.model.Customer
+import com.stripe.samplestore.service.SampleStoreEphemeralKeyProvider
+
+internal class StoreViewModel(application: Application) : AndroidViewModel(application) {
+    private val context = application.applicationContext
+    private val settings = Settings(context)
+    private val ephemeralKeyProvider = SampleStoreEphemeralKeyProvider(
+        context,
+        settings.stripeAccountId
+    )
+    private val customerSession: CustomerSession by lazy { CustomerSession.getInstance() }
+
+    init {
+        CustomerSession.initCustomerSession(
+            context,
+            ephemeralKeyProvider,
+            settings.stripeAccountId,
+            shouldPrefetchEphemeralKey = false
+        )
+    }
+
+    fun retrieveCustomer(): LiveData<Result<Customer>> {
+        val liveData = MutableLiveData<Result<Customer>>()
+        customerSession.retrieveCurrentCustomer(object : CustomerSession.CustomerRetrievalListener {
+            override fun onCustomerRetrieved(customer: Customer) {
+                liveData.value = Result.success(customer)
+            }
+
+            override fun onError(
+                errorCode: Int,
+                errorMessage: String,
+                stripeError: StripeError?
+            ) {
+                liveData.value = Result.failure(
+                    RuntimeException("Could not retrieve Customer. $errorMessage ($errorCode). $stripeError")
+                )
+            }
+        })
+        return liveData
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        ephemeralKeyProvider.destroy()
+    }
+}

--- a/app/src/main/java/com/stripe/samplestore/StripeFactory.kt
+++ b/app/src/main/java/com/stripe/samplestore/StripeFactory.kt
@@ -1,0 +1,19 @@
+package com.stripe.samplestore
+
+import android.content.Context
+import com.stripe.android.PaymentConfiguration
+import com.stripe.android.Stripe
+
+internal class StripeFactory(
+    private val context: Context,
+    private val enableLogging: Boolean = true
+) {
+    fun create(): Stripe {
+        return Stripe(
+            context,
+            PaymentConfiguration.getInstance(context).publishableKey,
+            Settings(context).stripeAccountId,
+            enableLogging
+        )
+    }
+}

--- a/app/src/main/res/layout/store_activity.xml
+++ b/app/src/main/res/layout/store_activity.xml
@@ -24,6 +24,14 @@
             app:popupTheme="@style/WhiteTextTheme"
             tools:ignore="UnusedAttribute" />
 
+        <ProgressBar
+            android:id="@+id/progress_bar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:visibility="invisible"
+            style="@style/Widget.AppCompat.ProgressBar.Horizontal"/>
+
         <androidx.recyclerview.widget.RecyclerView
             android:id="@+id/store_items"
             android:layout_width="match_parent"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-all.zip


### PR DESCRIPTION
- Create `StripeFactory` to simplify creating a `Stripe` instance
- Move API calls from `PaymentActivity` to `PaymentViewModel`
- Remove `"payment_method_id"` entry from create params - it is unused
  by the backend
- Update `StoreActivity` to only enable going to the checkout after
  a `Customer` has been retrieved
- Pass `customerId` in `CheckoutContract.Args`