### PR TITLE
Update version numbers of libraries

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -83,11 +83,11 @@ android {
 }
 
 dependencies {
-    implementation 'com.stripe:stripe-android:17.0.0'
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation 'com.stripe:stripe-android:17.2.0'
+    implementation 'androidx.appcompat:appcompat:1.3.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
-    implementation 'androidx.activity:activity-ktx:1.2.3'
-    implementation 'androidx.fragment:fragment-ktx:1.3.5'
+    implementation 'androidx.activity:activity-ktx:1.3.1'
+    implementation 'androidx.fragment:fragment-ktx:1.3.6'
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:2.3.1"
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'com.google.android.gms:play-services-wallet:18.1.3'
@@ -97,7 +97,7 @@ dependencies {
     implementation 'com.squareup.retrofit2:retrofit:2.9.0'
 
     /* Used to make Retrofit easier and GSON & Rx-compatible*/
-    implementation 'com.google.code.gson:gson:2.8.7'
+    implementation 'com.google.code.gson:gson:2.8.8'
     implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
 
     // Used to debug your Retrofit connections
@@ -109,11 +109,11 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutineVersion"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutineVersion"
 
-    ktlint 'com.pinterest:ktlint:0.41.0'
+    ktlint 'com.pinterest:ktlint:0.42.1'
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation 'org.mockito:mockito-core:3.11.2'
-    testImplementation 'org.robolectric:robolectric:4.5.1'
+    testImplementation 'org.mockito:mockito-core:3.12.4'
+    testImplementation 'org.robolectric:robolectric:4.6.1'
     testImplementation 'androidx.test:core:1.4.0'
     testImplementation 'org.json:json:20210307'
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.2.2'
+        classpath 'com.android.tools.build:gradle:7.0.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }


### PR DESCRIPTION
### Update versions:
stripe-android from 17.0.0 to 17.2.0
appcompat from 1.3.0 to 1.3.1
activity-ktx from 1.2.3 to 1.3.1
fragment-ktx from 1.3.5 to 1.3.6
gson from 2.8.7 to 2.8.8
ktlint from 0.41.0 to 0.42.1
mockito-core from 3.11.2 to 3.12.4
robolectric from 4.5.1 to 4.6.1